### PR TITLE
Treat #block element as Pre when plugin does not process it.

### DIFF
--- a/lib/convert_html.php
+++ b/lib/convert_html.php
@@ -147,8 +147,10 @@ function & Factory_Div(& $root, $text)
 		}
 	} else {
 		// Hack code
-		if(preg_match('/^#([^\(\{]+)(?:\(([^\r]*)\))?(\{*)/', $text, $matches) &&
-		   exist_plugin_convert($matches[1])) {
+		if(preg_match('/^#([^\(\{]+)(?:\(([^\r]*)\))?(\{*)/', $text, $matches)) {
+			if (!exist_plugin_convert($matches[1])) {
+				return new Pre($root, $text);
+			}
 			$len  = strlen($matches[3]);
 			$body = array();
 			if ($len == 0) {
@@ -156,6 +158,8 @@ function & Factory_Div(& $root, $text)
 			} else if (preg_match('/\{{' . $len . '}\s*\r(.*)\r\}{' . $len . '}/', $text, $body)) { 
 				$matches[2] .= "\r" . $body[1] . "\r";
 				return new Div($matches); // Seems multiline-enabled block plugin
+			} else {
+				return new Pre($root, $text);
 			}
 		}
 	}


### PR DESCRIPTION
- If corresponding plugin does not process #block element, it was treated as Paragraph, then inline elements were expanded.
  At some web server which has limited memory, preg_replace_callback() in InlineConverter::convert() cashes by illegal instruction exception.
  multiline-enabled #block element concatinates all lines in {{ }}, so memory consumption becomes severe and unpredictable.
